### PR TITLE
Implement support for sequelize@4

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/gbenvenuti/customulize",
   "devDependencies": {
     "grape": "^1.0.0",
-    "mockery": "^1.4.0"
+    "mockery": "^1.4.0",
+    "tape": "^4.8.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-var test = require('grape'),
+var test = require('tape'),
     propertyName = 'fakeProp',
     runTests = require('./runTests');
 
@@ -45,3 +45,4 @@ function createTestFunction(model, method) {
 runTests.sequelizeV1(test, propertyName, createTestFunction, successTestV1, errorTestV1);
 runTests.sequelizeV2(test, propertyName, createTestFunction, successTestV2, errorTestV2);
 runTests.sequelizeV3(test, propertyName, createTestFunction, successTestV2, errorTestV2);
+runTests.sequelizeV4(test, propertyName, createTestFunction, successTestV2, errorTestV2);


### PR DESCRIPTION
Implements support for sequelize version 4.

A breaking change in v4 ([Sequelize Upgrade Guide](http://docs.sequelizejs.com/manual/tutorial/upgrade-to-v4.html)) is that models are now constructors extending from `Model`.

This patch adds support to `customulize` for this new type of models while keeping existing functionality.